### PR TITLE
Define info color variable for API settings modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,6 +10,7 @@
   --secondary: #64748b;
   --secondary-hover: #475569;
   --success: #059669;
+  --info: #0ea5e9;
   --warning: #d97706;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
@@ -56,6 +57,7 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --info: #38bdf8;
 
   /* Background Colors - Dark Mode */
   --bg-primary: #0f172a;


### PR DESCRIPTION
## Summary
- add missing `--info` CSS variable for light and dark themes so API "Clear Cache" button renders with visible background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a4b352c8832e9483e0d76fa1bd86