### PR TITLE
Fix API settings Clear Cache button style

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,7 @@
   --warning: #d97706;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
+  --info: #0ea5e9;
 
   /* Background Colors */
   --bg-primary: #ffffff;
@@ -56,6 +57,7 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --info: #38bdf8;
 
   /* Background Colors - Dark Mode */
   --bg-primary: #0f172a;


### PR DESCRIPTION
## Summary
- add missing info color variable so Clear Cache button is visible in light mode

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6895a4b352c8832e9483e0d76fa1bd86