### PR TITLE
Add consistent styling for API settings cache button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,8 @@
   --warning: #d97706;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
+  --info: #0ea5e9;
+  --info-hover: #0284c7;
 
   /* Background Colors */
   --bg-primary: #ffffff;
@@ -56,6 +58,8 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --info: #38bdf8;
+  --info-hover: #0ea5e9;
 
   /* Background Colors - Dark Mode */
   --bg-primary: #0f172a;
@@ -301,6 +305,14 @@ button, .btn, input[type="button"], input[type="submit"] {
 
 .btn.danger:hover {
   background: var(--danger-hover);
+}
+
+.btn.info {
+  background: var(--info);
+}
+
+.btn.info:hover {
+  background: var(--info-hover);
 }
 
 .btn.premium {

--- a/index.html
+++ b/index.html
@@ -818,7 +818,7 @@ Your API key is stored locally and encrypted
 <div style="display: flex; gap: 0.75rem; justify-content: flex-end; margin-top: 1.5rem;">
 <button type="button" class="btn" id="apiCancelBtn">Cancel</button>
 <button type="button" class="btn" id="apiSyncNowBtn" style="background: var(--primary);" title="Force sync fresh data from API now">Sync Now</button>
-<button type="button" class="btn" id="apiClearCacheBtn" style="background: var(--info);" title="Clear cached data to force fresh API sync on next sync">Clear Cache</button>
+<button type="button" class="btn info" id="apiClearCacheBtn" title="Clear cached data to force fresh API sync on next sync">Clear Cache</button>
 <button type="button" class="btn" id="apiClearBtn" style="background: var(--warning);">Clear Config</button>
 <button type="submit" class="btn" id="apiSaveBtn" style="background: var(--success);">Save & Test</button>
 </div>


### PR DESCRIPTION
## Summary
- define `--info` color variables and `.btn.info` style
- use the new class for the Clear Cache button in the API settings popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a4b352c8832e9483e0d76fa1bd86