### PR TITLE
Define info theme color for Clear Cache button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Precious Metals Inventory Tool v3.1.8
+# Precious Metals Inventory Tool v3.1.9
 
 The Precious Metals Inventory Tool is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
-## 🆕 What's New in v3.1.8
+## 🆕 What's New in v3.1.9
+- **UI Consistency**: Clear Cache button now uses the new `--info` color variable for consistent styling across themes.
+
+## What's New in v3.1.8
 - **Full Backup System**: "Backup All Data" button creates a timestamped ZIP archive of the entire application state.
 - **Comprehensive Archive**: Includes inventory JSON, settings, spot price history, and exports (CSV, Excel, HTML) with restoration instructions.
 - **Client-Side Processing**: Uses JSZip to generate archives locally so your data never leaves the device.
@@ -166,7 +169,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.1.8
+**Current Version**: 3.1.9
 **Last Updated**: August 7, 2025
 **Status**: Feature complete with comprehensive backup functionality
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -10,6 +10,7 @@
   --secondary: #64748b;
   --secondary-hover: #475569;
   --success: #059669;
+  --info: #0ea5e9;
   --warning: #d97706;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
@@ -56,6 +57,7 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --info: #38bdf8;
 
   /* Background Colors - Dark Mode */
   --bg-primary: #0f172a;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 📋 Version History
 
+### Version 3.1.9 – API Modal Button Styling Fix (2025-08-07)
+- **UI Consistency**: Added `--info` CSS variable and updated Clear Cache button to ensure visible, uniform styling across themes.
+
 ### Version 3.1.8 – Comprehensive Backup ZIP Functionality (2025-08-07)
 - **New feature**: Implemented complete backup system with ZIP file download
 - **Comprehensive backup**: Creates ZIP archive containing all application data

--- a/docs/LLM.md
+++ b/docs/LLM.md
@@ -16,7 +16,7 @@
 
 ## 1. Purpose
 
-Provide AI assistants (LLMs) a concise, up-to-date overview of the **Precious Metals Inventory Tool v3.1.8** to guide development, documentation, and QA tasks.
+Provide AI assistants (LLMs) a concise, up-to-date overview of the **Precious Metals Inventory Tool v3.1.9** to guide development, documentation, and QA tasks.
 
 ## 2. Project Snapshot
 
@@ -29,7 +29,7 @@ Provide AI assistants (LLMs) a concise, up-to-date overview of the **Precious Me
   - **Comprehensive backup ZIP system** with all data formats and restoration guides
   - Responsive & accessible UI (mobile-first, ARIA, keyboard support)  
   - Modular JS architecture (constants, state, events, utils, inventory)  
-- **Version**: 3.1.8 (backup ZIP functionality)  
+- **Version**: 3.1.9 (API modal button styling fix)
 - **Last Updated**: August 7, 2025  
 
 ## 3. Project Structure
@@ -87,16 +87,12 @@ PreciousMetalInventoryTool/
 5. **Import/Export Schema**  
    - Ensure all fields (notes, storage, overrides) are serialized/deserialized  
 
-## 6. v3.1.8 Spotlight
+## 6. v3.1.9 Spotlight
 
-- **Comprehensive Backup ZIP System**:  
-  - **createBackupZip()**: Generates complete archive with all data formats  
-  - **Archive Contents**: JSON data, CSV/Excel exports, HTML reports, settings, spot history  
-  - **Restoration Guide**: Detailed README.txt with recovery instructions  
-  - **Dependencies**: Added JSZip library for reliable ZIP file creation  
-  - **User Experience**: Loading indicator, success confirmation, error handling  
-- **Data Integrity**: Multiple format redundancy ensures recovery options  
-- **Privacy**: All processing client-side, no data transmission  
+- **UI Consistency Improvement**:
+  - Added `--info` CSS variable for theming
+  - Clear Cache button in API settings popup now visibly styled across light and dark modes
+  - Ensures uniform appearance with other action buttons
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - Precious Metals Inventory Tool
 
-## 🎯 Current State: **FEATURE COMPLETE v3.1.8** ✅ BACKUP ZIP IMPLEMENTED
+## 🎯 Current State: **FEATURE COMPLETE v3.1.9** ✅ API UI POLISH
 
-**Precious Metals Inventory Tool v3.1.8** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. 
+**Precious Metals Inventory Tool v3.1.9** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities.
 
 ## 🏗️ Architecture Overview
 
@@ -18,16 +18,9 @@ The tool features a **modular JavaScript architecture** with separate files for 
 - `theme.js` - Dark/light theme management
 - `utils.js` - Helper functions and formatters
 
-## ✨ Latest Feature (v3.1.8)
+## ✨ Latest Change (v3.1.9)
 
-We implemented **comprehensive backup ZIP functionality** which:
-- ✅ Complete backup system with ZIP file download
-- ✅ Multiple export formats included in single archive
-- ✅ Comprehensive data preservation (inventory, settings, history)
-- ✅ Self-contained HTML reports and README instructions
-- ✅ Timestamped backup files for easy organization
-- ✅ Client-side processing ensuring complete privacy
-- ✅ Error handling with user-friendly messages
+- **UI Consistency**: Clear Cache button in API settings popup now styled with new `--info` color variable for better visibility across themes.
 
 ## 🚀 Key Features
 
@@ -107,7 +100,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.1.8 (managed in `app/js/constants.js`)
+1. **Current Version**: 3.1.9 (managed in `app/js/constants.js`)
 2. **Last Feature**: Comprehensive backup ZIP functionality completed and documented
 3. **Last Documentation Update**: August 7, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/js/constants.js
+++ b/js/constants.js
@@ -63,7 +63,7 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = '3.1.8';
+const APP_VERSION = '3.1.9';
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
 const LS_KEY = 'metalInventory';

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # Precious Metals Inventory Tool - Project Structure
 
-## Current Structure (Version 3.1.8)
+## Current Structure (Version 3.1.9)
 
 ```text
 ├── STRUCTURE.md


### PR DESCRIPTION
## Summary
- add `--info` CSS variable for light and dark themes
- use new color so Clear Cache button matches other API modal actions
- bump version to 3.1.9 and sync project docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a4b352c8832e9483e0d76fa1bd86