### PR TITLE
style: externalize resize handle CSS

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -798,6 +798,17 @@ td input:checked + .slider:before {
 }
 
 /* Resize handle styling */
+.resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 6px;
+  height: 100%;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 10;
+  transition: background-color 0.2s;
+}
 .resize-handle:hover {
   background: var(--primary) !important;
   opacity: 0.7;

--- a/js/events.js
+++ b/js/events.js
@@ -68,17 +68,6 @@ const setupColumnResizing = () => {
 
     const resizeHandle = document.createElement('div');
     resizeHandle.className = 'resize-handle';
-    resizeHandle.style.cssText = `
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: 6px;
-      height: 100%;
-      background: transparent;
-      cursor: col-resize;
-      z-index: 10;
-      transition: background-color 0.2s;
-    `;
 
     header.style.position = 'relative';
     header.appendChild(resizeHandle);


### PR DESCRIPTION
## Summary
- move resize handle inline styles to new `.resize-handle` rule in stylesheet
- create handles with CSS class only

## Testing
- `node /tmp/test_resize.js`

------
https://chatgpt.com/codex/tasks/task_e_6895ff62dbd0832e8a0fd176f7497b9b