### PR TITLE
fix initialization debug errors

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -127,7 +127,6 @@ const setupColumnResizing = () => {
 const setupEventListeners = () => {
 
   console.log(`Setting up event listeners (v${APP_VERSION})...`);
- dev
 
   try {
     // CRITICAL HEADER BUTTONS

--- a/js/file-protocol-fix.js
+++ b/js/file-protocol-fix.js
@@ -1,12 +1,19 @@
 // SIMPLIFIED FILE PROTOCOL COMPATIBILITY
 // =============================================================================
 // Minimal file:// protocol fixes without conflicts
+const safeDebug = (...args) => {
+  if (typeof debugLog === 'function') {
+    debugLog(...args);
+  } else {
+    console.log('[DEBUG]', ...args);
+  }
+};
 
-debugLog('Loading simplified file:// protocol compatibility...');
+safeDebug('Loading simplified file:// protocol compatibility...');
 
 // Only provide essential localStorage fallback for file:// protocol
 if (window.location.protocol === 'file:') {
-  debugLog('File protocol detected - enabling localStorage fallback');
+  safeDebug('File protocol detected - enabling localStorage fallback');
   
   // Create memory storage fallback if localStorage fails
   window.tempStorage = window.tempStorage || {};
@@ -42,6 +49,6 @@ if (window.location.protocol === 'file:') {
   };
 }
 
-debugLog('File protocol compatibility loaded');
+safeDebug('File protocol compatibility loaded');
 
 // =============================================================================

--- a/js/init.js
+++ b/js/init.js
@@ -45,8 +45,7 @@ function safeGetElement(id, required = false) {
 document.addEventListener('DOMContentLoaded', () => {
 
   console.log(`=== APPLICATION INITIALIZATION STARTED (v${APP_VERSION}) ===`);
-dev
-  
+
   try {
     // Phase 1: Initialize Core DOM Elements
     debugLog('Phase 1: Initializing core DOM elements...');


### PR DESCRIPTION
## Summary
- add safeDebug function in file-protocol-fix to avoid debugLog reference errors
- remove stray dev tokens from initialization and event listener scripts

## Testing
- `node --check js/file-protocol-fix.js`
- `node --check js/init.js`
- `node --check js/events.js`


------
https://chatgpt.com/codex/tasks/task_e_689604b38f38832e9f6e545ead253e05