### PR TITLE
Refine inventory table display

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -663,14 +663,14 @@ th:nth-child(3) { width: 45px; }   /* Qty */
 th:nth-child(4) { width: 60px; }   /* Type */
 th:nth-child(5) { width: 120px; }  /* Name - clickable */
 th:nth-child(6) { width: 80px; }   /* Weight */
-th:nth-child(7) { width: 90px; }   /* Purchase Price */
-th:nth-child(8) { width: 85px; }   /* Spot Price */
-th:nth-child(9) { width: 85px; }   /* Premium */
-th:nth-child(10) { width: 100px; } /* Total Premium */
-th:nth-child(11) { width: 110px; } /* Purchase Location */
-th:nth-child(12) { width: 110px; } /* Storage Location */
-th:nth-child(13) { width: 80px; }  /* Date */
-th:nth-child(14) { width: 70px; }  /* Collectable - checkbox */
+th:nth-child(7) { width: 90px; }   /* Purchase Price Paid */
+th:nth-child(8) { width: 85px; }   /* Spot Price at Purchase */
+th:nth-child(9) { width: 100px; } /* Total Premium */
+th:nth-child(10) { width: 110px; } /* Purchase Location */
+th:nth-child(11) { width: 110px; } /* Storage Location */
+th:nth-child(12) { width: 80px; }  /* Date */
+th:nth-child(13) { width: 70px; }  /* Collectable - checkbox */
+th:nth-child(14) { width: 70px; }  /* Notes */
 th:nth-child(15) { width: 50px; }  /* Delete */
 
 /* Clickable name cell styling */
@@ -1471,14 +1471,14 @@ input:disabled + .slider {
   th:nth-child(4) { width: 50px; }   /* Type */
   th:nth-child(5) { width: 100px; }  /* Name */
   th:nth-child(6) { width: 70px; }   /* Weight */
-  th:nth-child(7) { width: 80px; }   /* Purchase Price */
-  th:nth-child(8) { width: 75px; }   /* Spot Price */
-  th:nth-child(9) { width: 75px; }   /* Premium */
-  th:nth-child(10) { width: 85px; }  /* Total Premium */
-  th:nth-child(11) { width: 90px; }  /* Purchase Location */
-  th:nth-child(12) { width: 90px; }  /* Storage Location */
-  th:nth-child(13) { width: 70px; }  /* Date */
-  th:nth-child(14) { width: 60px; }  /* Collectable */
+  th:nth-child(7) { width: 80px; }   /* Purchase Price Paid */
+  th:nth-child(8) { width: 75px; }   /* Spot Price at Purchase */
+  th:nth-child(9) { width: 85px; }  /* Total Premium */
+  th:nth-child(10) { width: 90px; }  /* Purchase Location */
+  th:nth-child(11) { width: 90px; }  /* Storage Location */
+  th:nth-child(12) { width: 70px; }  /* Date */
+  th:nth-child(13) { width: 60px; }  /* Collectable */
+  th:nth-child(14) { width: 60px; }  /* Notes */
   th:nth-child(15) { width: 40px; }  /* Delete */
 }
 

--- a/index.html
+++ b/index.html
@@ -500,14 +500,14 @@
 <th>Type</th>
 <th>Name</th>
 <th>Weight (oz)</th>
-<th>Purchase Price ($)</th>
-<th>Spot Price ($/oz)</th>
-<th>Premium Paid ($/oz)</th>
+<th>Purchase Price Paid ($)</th>
+<th>Spot Price at Purchase ($/oz)</th>
 <th>Total Premium Paid ($)</th>
 <th>Purchase Location</th>
 <th>Storage Location</th>
 <th>Date</th>
 <th>Collectable</th>
+<th>Notes</th>
 <th>Delete</th>
 </tr>
 </thead>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -443,7 +443,6 @@ const renderTable = () => {
       <td>${parseFloat(item.weight).toFixed(2)}</td>
       <td>${formatDollar(item.price)}</td>
       <td>${item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatDollar(item.spotPriceAtPurchase) : 'N/A')}</td>
-      <td style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.premiumPerOz > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.premiumPerOz)}</td>
       <td style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.totalPremium)}</td>
       <td>${sanitizeHtml(item.purchaseLocation)}</td>
       <td>${sanitizeHtml(item.storageLocation || 'Unknown')}</td>
@@ -451,6 +450,7 @@ const renderTable = () => {
       <td class="checkbox-cell">
       <input type="checkbox" ${item.isCollectable ? 'checked' : ''} onchange="toggleCollectable(${originalIdx}, this)" class="collectable-checkbox" aria-label="Mark ${sanitizeHtml(item.name)} as collectable" title="Mark as collectable">
       </td>
+      <td><button class="btn" onclick="showNotes(${originalIdx})" aria-label="View notes">📝</button></td>
       <td class="delete-cell"><button class="btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item">&times;</button></td>
       </tr>
       `);
@@ -677,8 +677,19 @@ const updateSummary = () => {
 };
 
 /**
+ * Displays notes for a specific inventory item in a popup text box
+ *
+ * @param {number} idx - Index of the item to display notes for
+ */
+const showNotes = (idx) => {
+  const item = inventory[idx];
+  const notes = item.notes || 'No notes available';
+  window.prompt('Item Notes', notes);
+};
+
+/**
  * Deletes inventory item at specified index after confirmation
- * 
+ *
  * @param {number} idx - Index of item to delete
  */
 const deleteItem = (idx) => {

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -21,13 +21,13 @@ const sortInventory = (data = inventory) => {
       case 4: valA = a.name; valB = b.name; break; // Name
       case 5: valA = a.weight; valB = b.weight; break; // Weight
       case 6: valA = a.price; valB = b.price; break; // Purchase Price
-      case 7: valA = a.spotPriceAtPurchase; valB = b.spotPriceAtPurchase; break; // Spot Price
-      case 8: valA = a.premiumPerOz; valB = b.premiumPerOz; break; // Premium per oz
-      case 9: valA = a.totalPremium; valB = b.totalPremium; break; // Total Premium
-      case 10: valA = a.purchaseLocation; valB = b.purchaseLocation; break; // Purchase Location
-      case 11: valA = a.storageLocation || 'Unknown'; valB = b.storageLocation || 'Unknown'; break; // Storage Location
-      case 12: valA = a.date; valB = b.date; break; // Date
-      case 13: valA = a.isCollectable; valB = b.isCollectable; break; // Collectable
+      case 7: valA = a.spotPriceAtPurchase; valB = b.spotPriceAtPurchase; break; // Spot Price at Purchase
+      case 8: valA = a.totalPremium; valB = b.totalPremium; break; // Total Premium
+      case 9: valA = a.purchaseLocation; valB = b.purchaseLocation; break; // Purchase Location
+      case 10: valA = a.storageLocation || 'Unknown'; valB = b.storageLocation || 'Unknown'; break; // Storage Location
+      case 11: valA = a.date; valB = b.date; break; // Date
+      case 12: valA = a.isCollectable; valB = b.isCollectable; break; // Collectable
+      case 13: valA = a.notes || ''; valB = b.notes || ''; break; // Notes
       default: return 0;
     }
 


### PR DESCRIPTION
## Summary
- clarify purchase and spot price headers to reflect purchase-time values
- hide premium-per-ounce column and add notes popup button
- update sorting and styling to match revised column layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689608441318832eb03370a035741ab5